### PR TITLE
fix(Dockerfile): ignore scripts during dependency install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN npm install --global pm2 pnpm
 COPY package.json pnpm-lock.yaml ./
 
 # Install dependencies using pnpm
-RUN pnpm install --prod
+RUN pnpm install --prod --ignore-scripts
 
 # Copy all application files
 COPY . .


### PR DESCRIPTION
Update the Dockerfile to include the `--ignore-scripts` flag in the 
`pnpm install` command. This change prevents the execution of scripts 
defined in package.json during the installation of production 
dependencies, which can help avoid potential issues related to 
unnecessary script execution in the container environment.