### PR TITLE
refactor: optimize Dockerfile for production image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ COPY . .
 # Build the application
 RUN pnpm run build
 
-# Remove devDependencies to optimize production image
-RUN pnpm prune --prod
+# Prune devDependencies without running lifecycle scripts
+RUN pnpm prune --prod --no-optional --ignore-scripts
 
 # Expose the application port
 EXPOSE 8080


### PR DESCRIPTION
Prune devDependencies in the Dockerfile without running 
lifecycle scripts to reduce the image size and improve 
build efficiency. This change enhances the production 
image by ensuring only necessary dependencies are 
included, while avoiding potential issues from 
unnecessary scripts.