### PR TITLE
chore: update environment configuration for production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,6 @@ RUN pnpm install
 # Copy all application files
 COPY . .
 
-# Copy .env.production to .env
-COPY .env.production .env
-
 # Build the application
 RUN pnpm run build
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   nestjs:
     build: ./
     env_file:
-      - .env
+      - .env.production
   nginx:
     build: ./nginx
     ports:


### PR DESCRIPTION
Switches the environment file in the Docker Compose 
configuration from `.env` to `.env.production` to 
ensure the application uses the correct settings for 
production. Removes the step that copies the 
`.env.production` file to `.env` in the Dockerfile, 
as it is no longer necessary.