### PR TITLE
fix: update NGINX to listen on port 8080

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
+PORT=8080
+
 # Database
 DB_HOST=ep-royal-sunset-a1xwu62v.ap-southeast-1.aws.neon.tech
 DB_USERNAME=neondb_owner

--- a/.env.production
+++ b/.env.production
@@ -1,4 +1,5 @@
 NODE_ENV=production
+PORT=8080
 
 # Database
 DB_HOST=ep-royal-sunset-a1xwu62v.ap-southeast-1.aws.neon.tech

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,4 +7,4 @@ services:
   nginx:
     build: ./nginx
     ports:
-      - 80:80
+      - 8080:8080

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -8,7 +8,7 @@ RUN rm /etc/nginx/conf.d/*
 COPY ./default.conf /etc/nginx/conf.d/
 
 # Expose the listening port
-EXPOSE 80
+EXPOSE 8080
 
 # Launch NGINX
 CMD [ "nginx", "-g", "daemon off;" ]

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -6,7 +6,7 @@ upstream nestjs {
 }
 
 server {
-  listen 80 default_server;
+  listen 8080;
 
   server_name _;
 


### PR DESCRIPTION
Change NGINX configuration to listen on port 8080 instead of 80. 
Update Dockerfile to expose port 8080. Modify environment files 
to set the PORT variable to 8080. Adjust docker-compose to map 
the correct port for the NGINX service. These changes ensure 
consistency across configurations and avoid conflicts with 
other services that may use port 80.