### PR TITLE
fix: update server binding and clean up configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,6 @@ RUN pnpm run build
 # Prune devDependencies without running lifecycle scripts
 RUN pnpm prune --prod --no-optional --ignore-scripts
 
-# Set environment variable for port
-ENV PORT=8001
-
 # Expose the application port
 EXPOSE 8001
 

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -23,14 +23,6 @@ server {
   proxy_set_header Host $host;
   proxy_cache_bypass $http_upgrade;
 
-  # BUILT ASSETS (E.G. JS BUNDLES)
-  # Browser cache - max cache headers from Next.js as build id in url
-  # Server cache - valid forever (cleared after cache "inactive" period)
-  location /_next/static {
-    proxy_cache STATIC;
-    proxy_pass http://nestjs;
-  }
-
   # STATIC ASSETS (E.G. IMAGES)
   # Browser cache - "no-cache" headers from Next.js as no build id in url
   # Server cache - refresh regularly in case of changes

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,6 +39,6 @@ const bootstrap = async () => {
 
   app.setGlobalPrefix("api/v1");
   app.enableCors();
-  await app.listen(process.env.PORT ?? 8001);
+  await app.listen(process.env.PORT ?? 8001, "0.0.0.0");
 };
 bootstrap();


### PR DESCRIPTION
Set the application to listen on all network interfaces by 
binding to "0.0.0.0". Remove unnecessary configuration 
related to static asset caching in Nginx and clean up the 
Dockerfile by removing the environment variable for the 
port, as it is now handled directly in the application. 
These changes improve accessibility and simplify the 
deployment configuration.