### PR TITLE
feat: copy build output into Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,9 @@ COPY . .
 # Build the application
 RUN pnpm run build
 
+# Copy the build output into the container
+COPY ./dist ./dist
+
 # Prune devDependencies without running lifecycle scripts
 RUN pnpm prune --prod --no-optional --ignore-scripts
 


### PR DESCRIPTION
Add a step to the Dockerfile to copy the build output from the  dist directory into the container. This ensures that the built  application is available for execution within the container.